### PR TITLE
TDEVOPS-1904 | Handling comment as review and approval corner cases

### DIFF
--- a/.github/workflows/master_approve.yml
+++ b/.github/workflows/master_approve.yml
@@ -76,7 +76,9 @@ jobs:
       - name: Fetch and Rerun Failed workflow
         run: |
           WORKFLOW_ID=$(gh run list --branch "${{github.event.pull_request.head.ref}}" --status 'failure' --event 'pull_request' --workflow 'Master CI Approve Workflow' --limit 1 --json 'workflowDatabaseId' | jq '.[0].workflowDatabaseId')
+          echo $WORKFLOW_ID
           if [[ ! -z "$WORKFLOW_ID" ]]; then
+            echo "Rerunning Failed Approval Workflow"
             gh run rerun $WORKFLOW_ID --failed
           fi
 

--- a/.github/workflows/master_approve.yml
+++ b/.github/workflows/master_approve.yml
@@ -79,7 +79,7 @@ jobs:
           echo $WORKFLOW_ID
           if [[ ! -z "$WORKFLOW_ID" ]]; then
             echo "Rerunning Failed Approval Workflow"
-            gh run rerun $WORKFLOW_ID --failed
+            gh run rerun $WORKFLOW_ID --failed -f exclude_pull_requests=false
           fi
 
   auto-merge:

--- a/.github/workflows/master_approve.yml
+++ b/.github/workflows/master_approve.yml
@@ -75,7 +75,7 @@ jobs:
       
       - name: Fetch and Rerun Failed workflow
         run: |
-          WORKFLOW_ID=$(gh run list --branch "${{github.head_ref}}" --status 'failure' --event 'pull_request' --workflow 'Master CI Approve Workflow' --limit 1 --json 'workflowDatabaseId' | jq '.[0].workflowDatabaseId')
+          WORKFLOW_ID=$(gh run list --branch "${{github.event.pull_request.head.ref}}" --status 'failure' --event 'pull_request' --workflow 'Master CI Approve Workflow' --limit 1 --json 'workflowDatabaseId' | jq '.[0].workflowDatabaseId')
           if [[ ! -z "$WORKFLOW_ID" ]]; then
             gh run rerun $WORKFLOW_ID --failed
           fi

--- a/.github/workflows/master_approve.yml
+++ b/.github/workflows/master_approve.yml
@@ -57,11 +57,28 @@ jobs:
 
   check-approval:
     needs: [check-update-branch,read-codeowners]
-    if: ${{ github.event.review.state == 'approved' || needs.check-update-branch.outputs.update-branch == 'true' }}
+    if: ${{ github.event.review.state == 'approved' || github.event.review.state == 'commented' || github.event.review.state == 'changes_requested' || needs.check-update-branch.outputs.update-branch == 'true' }}
     uses: TessellDevelopment/convoy-ci/.github/workflows/master_check_approval.yml@main
     secrets: inherit
     with:
       required-teams: ${{needs.read-codeowners.outputs.required-teams}}
+
+  rerun-approval:
+    needs: [check-approval]
+    if: ${{ github.event.review.state == 'approved' }}
+    runs-on: non-build
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+          token: ${{secrets.CIPIPELINE_GITHUB_TOKEN}}
+      
+      - name: Fetch and Rerun Failed workflow
+        run: |
+          WORKFLOW_ID=$(gh run list --branch "${{github.head_ref}}" --status 'failure' --event 'pull_request' --workflow 'Master CI Approve Workflow' --limit 1 --json 'workflowDatabaseId' | jq '.[0].workflowDatabaseId')
+          if [[ ! -z "$WORKFLOW_ID" ]]; then
+            gh run rerun $WORKFLOW_ID --failed
+          fi
 
   auto-merge:
     needs: check-approval

--- a/.github/workflows/master_approve.yml
+++ b/.github/workflows/master_approve.yml
@@ -75,11 +75,11 @@ jobs:
       
       - name: Fetch and Rerun Failed workflow
         run: |
-          WORKFLOW_ID=$(gh run list --branch "${{github.event.pull_request.head.ref}}" --status 'failure' --event 'pull_request' --workflow 'Master CI Approve Workflow' --limit 1 --json 'workflowDatabaseId' | jq '.[0].workflowDatabaseId')
+          WORKFLOW_ID=$(gh run list --branch "${{github.event.pull_request.head.ref}}" --status 'failure' --event 'pull_request' --workflow 'Master CI Approve Workflow' --limit 1 --json 'databaseId' | jq '.[0].databaseId')
           echo $WORKFLOW_ID
           if [[ ! -z "$WORKFLOW_ID" ]]; then
             echo "Rerunning Failed Approval Workflow"
-            gh run rerun $WORKFLOW_ID --failed -f exclude_pull_requests=false
+            gh run rerun $WORKFLOW_ID --failed
           fi
 
   auto-merge:

--- a/.github/workflows/master_check_approval.yml
+++ b/.github/workflows/master_check_approval.yml
@@ -77,4 +77,5 @@ jobs:
                 echo "Approval not present for $TEAM team."
                 exit 1
               fi
+              
             done


### PR DESCRIPTION
Handling Approval corner cases

- `Comment as Review`: Since comments and Requested changes are treated as review and trigger Approval workflow, it becomes necessary to run Approval / check approval such that if comment is added after getting approval on PR it doesn't overwrites it with `Expected` check.

- `Update Branch before Approval` : Update branch is treated as `pull_request` trigger while approval, comment, changes requested are treated as `pull_request_review` if update-branch happens before approval if fails approval with pull_request trigger and after getting approval under `pull_request_review` trigger it remain as it is in failed state. So handled re-run of workflow under `pull_request` trigger to avoid manual re-run for merge. 