### PR TITLE
TDEVOPS-3459 | Make build API to convoy dependent on post tag API

### DIFF
--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -131,7 +131,7 @@ jobs:
 
   post-build-to-convoy:
     if: always()
-    needs: [file-check, create-tag, build, runner-check]
+    needs: [file-check, create-tag, build, runner-check, post-tag-to-convoy]
     uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_build_convoy.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Dependent Services #
- [ ] Governance
- [ ] IAM
- [ ] Deployer
- [ ] DB Systems
- [ ] Tenant
- [ ] Software Library
- [ ] Backup
- [ ] Conductor
- [ ] Monitoring
- [ ] DMM

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Environment**:

- [ ] Dev
- [ ] Staging

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the build-to-convoy workflow to run only after the post-tag-to-convoy step completes.

<!-- End of auto-generated description by cubic. -->

