### PR TITLE
TDEVOPS-4371 | Fix custom_buckets init to empty array instead of an unset var

### DIFF
--- a/.github/ci-scripts/bash/functions-for-artifacts-upload
+++ b/.github/ci-scripts/bash/functions-for-artifacts-upload
@@ -26,7 +26,8 @@ function upload_to_nexus_tessell_artifacts() {
 }
 
 function resolve_artifact_buckets() {
-  local artifact_name="${1:-}" convoy_yaml="${2:-./convoy.yaml}" custom_buckets
+  local artifact_name="${1:-}" convoy_yaml="${2:-./convoy.yaml}"
+  local -a custom_buckets=()
 
   if [[ -n "${artifact_name}" && -f "${convoy_yaml}" ]]; then
     readarray -t custom_buckets < <(


### PR DESCRIPTION
…nset var

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Dependent Services #
- [ ] Governance
- [ ] IAM
- [ ] Deployer
- [ ] DB Systems
- [ ] Tenant
- [ ] Software Library
- [ ] Backup
- [ ] Conductor
- [ ] Monitoring
- [ ] DMM

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Environment**:

- [ ] Dev
- [ ] Staging

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
