### PR TITLE
TDEVOPS-4679 | Updated UT to pick up convoy python version

### DIFF
--- a/.github/ci-scripts/bash/create-crdc
+++ b/.github/ci-scripts/bash/create-crdc
@@ -11,7 +11,7 @@ cleanup() {
 trap cleanup EXIT
 
 function fetch_crdc_mappings() {
-  local api_url="http://${CONVOY_API_ENDPOINT}/devops/git-metadata/crdc?sourceAppGroup=${APP_GROUP}&sourceBranch=${PR_BASE_BRANCH}"
+  local api_url="http://${CONVOY_DEV_API_ENDPOINT}/devops/git-metadata/crdc?sourceAppGroup=${APP_GROUP}&sourceBranch=${PR_BASE_BRANCH}"
   local response=$(curl -sf -w "\n%{http_code}" "${api_url}" \
     -H "X-Api-Key: ${CONVOY_API_KEY}" \
     -H "Content-Type: application/json" 2>/dev/null || echo -e "\n000")

--- a/.github/ci-scripts/bash/functions-for-build
+++ b/.github/ci-scripts/bash/functions-for-build
@@ -147,10 +147,10 @@ check_flyway() {
   fi
 }
 
-select_python_version() {
+configure_python_version_if_required() {
   check_convoy_yaml
   required_python_version=$(yq e '.pythonVersion // ""' convoy.yaml 2>/dev/null)
-  [[ -n "${required_python_version:-}" ]] ||        return 0
+  [[ -n "${required_python_version:-}" ]] || return 0
   echo "Python version declared in convoy.yaml: ${required_python_version}" >&2
 
   if ! is_pyenv_version_installed "${required_python_version}";  then
@@ -158,13 +158,16 @@ select_python_version() {
     pyenv install "${required_python_version}"
   fi
   pyenv local "${required_python_version}"
+  python --version
 }
 
-configure_python_version_if_required() {
-  select_python_version || return 0
-  [[ -f .python-version ]] || return 0
-  python3 -m venv venv
-  source venv/bin/activate
+create_python_venv() {
+  check_convoy_yaml
+  required_python_version=$(yq e '.pythonVersion // ""' convoy.yaml 2>/dev/null)
+  [[ -n "${required_python_version:-}" ]] || return 0
+  local venv_name="${1:-venv}"
+  python3 -m venv "${venv_name}"
+  source "${venv_name}/bin/activate"
   python --version
 }
 
@@ -739,7 +742,6 @@ image_scan(){
 
 initialise_coverage() {
   echo "Setting up virtual environment for running unit tests."
-  select_python_version
   venv_name=${1}
   venv_path=${PWD}/${venv_name}
   python_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
@@ -765,7 +767,7 @@ initialize_python_build_env() {
   ARTIFACT="${1}"
   requiredInputs="1"
   validateInputs "$requiredInputs" "$@"
-  configure_python_version_if_required
+  create_python_venv
   install_python_dependencies "$ARTIFACT"
   lintCheck
 }
@@ -1360,6 +1362,7 @@ python_library_build() {
   set -e
   initialize_python_build_env "$@"
   gradlewPythonwheel
+  deactivate 2>/dev/null || true
   set +e
 }
 
@@ -1367,6 +1370,7 @@ python_library_build_and_push() {
   set -e
   initialize_python_build_env "$@"
   gradlewTwineUpload
+  deactivate 2>/dev/null || true
   set +e
 }
 
@@ -1474,7 +1478,7 @@ setup_qa_env() {
 
 setup_packer_env() {
   python -m pip uninstall -y packer_framework
-  configure_python_version_if_required
+  create_python_venv
   python -m pip install wheel
   python -m pip install -r ./requirements.txt --trusted-host ${NEXUS_SERVER_ENDPOINT} --extra-index-url=${NEXUS_PROTOCOL}://${NEXUS_USERNAME}:${NEXUS_PASSWORD}@${NEXUS_SERVER_ENDPOINT}/repository/${NEXUS_PULL_REPOS_PY}/simple
   if [[ "${APP_GROUP}" == "tessell" ]]; then
@@ -1565,12 +1569,14 @@ software_def_build() {
     git diff origin/${GITHUB_BASE_REF} --compact-summary  > ../current_pr_diff
     if [[ ! $(diff ../root_pr_diff ../current_pr_diff) ]]; then
       echo "${BRANCH_NAME} contains double_commit and no pr diff, skipping build"
+      deactivate 2>/dev/null || true
       set +e
       return
     fi
   fi
   [[ "${ENABLE_PACKER_E2E_SCAN}" == "true" && "$GITHUB_DRAFT" != "true" ]] && e2e_flag="--is_e2e_test" || e2e_flag=""
   validate_all -r "$PWD" --dest_branch "$GITHUB_BASE_REF" --src_branch "$SOURCE_BRANCH" --pipeline_run ${e2e_flag}
+  deactivate 2>/dev/null || true
   set +e
 }
 
@@ -1599,6 +1605,7 @@ software_def_build_and_push() {
     build_all_artifacts -r $PWD --base_commit  --pipeline_run
   fi
   push_to_nexus "./common_manifest.json" "${NEXUS_ARTIFACT_BUCKET}/${LABEL}/delta-image-manifest/delta-image-manifest-${LATEST_TAG}.json"
+  deactivate 2>/dev/null || true
   set +e
 }
 

--- a/.github/ci-scripts/bash/functions-for-build
+++ b/.github/ci-scripts/bash/functions-for-build
@@ -147,10 +147,10 @@ check_flyway() {
   fi
 }
 
-configure_python_version_if_required() {
+select_python_version() {
   check_convoy_yaml
   required_python_version=$(yq e '.pythonVersion // ""' convoy.yaml 2>/dev/null)
-  [[ -n "${required_python_version:-}" ]] || return 0
+  [[ -n "${required_python_version:-}" ]] ||        return 0
   echo "Python version declared in convoy.yaml: ${required_python_version}" >&2
 
   if ! is_pyenv_version_installed "${required_python_version}";  then
@@ -158,6 +158,11 @@ configure_python_version_if_required() {
     pyenv install "${required_python_version}"
   fi
   pyenv local "${required_python_version}"
+}
+
+configure_python_version_if_required() {
+  select_python_version || return 0
+  [[ -f .python-version ]] || return 0
   python3 -m venv venv
   source venv/bin/activate
   python --version
@@ -734,6 +739,7 @@ image_scan(){
 
 initialise_coverage() {
   echo "Setting up virtual environment for running unit tests."
+  select_python_version
   venv_name=${1}
   venv_path=${PWD}/${venv_name}
   python_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")

--- a/.github/ci-scripts/bash/functions-for-build
+++ b/.github/ci-scripts/bash/functions-for-build
@@ -147,6 +147,15 @@ check_flyway() {
   fi
 }
 
+resolve_pyenv_python() {
+  local version="${1}"
+  local resolved
+  resolved=$(pyenv latest "${version}" 2>/dev/null) || \
+    resolved=$(pyenv versions --bare | grep -E "^${version}([.]|$)" | tail -1)
+  [[ -n "${resolved}" ]] || resolved="${version}"
+  echo "$(pyenv root)/versions/${resolved}/bin/python"
+}
+
 configure_python_version_if_required() {
   check_convoy_yaml
   required_python_version=$(yq e '.pythonVersion // ""' convoy.yaml 2>/dev/null)
@@ -157,7 +166,7 @@ configure_python_version_if_required() {
     echo "Python ${required_python_version} not found. Installing..."
     pyenv install "${required_python_version}"
   fi
-  "$(pyenv root)/versions/${required_python_version}/bin/python" --version
+  "$(resolve_pyenv_python "${required_python_version}")" --version
 }
 
 create_python_venv() {
@@ -165,7 +174,7 @@ create_python_venv() {
   required_python_version=$(yq e '.pythonVersion // ""' convoy.yaml 2>/dev/null)
   local venv_name="${1:-venv}"
   if [[ -n "${required_python_version:-}" ]]; then
-    "$(pyenv root)/versions/${required_python_version}/bin/python" -m venv "${venv_name}"
+    "$(resolve_pyenv_python "${required_python_version}")" -m venv "${venv_name}"
   else
     python3 -m venv "${venv_name}"
   fi

--- a/.github/ci-scripts/bash/functions-for-build
+++ b/.github/ci-scripts/bash/functions-for-build
@@ -158,6 +158,7 @@ configure_python_version_if_required() {
     pyenv install "${required_python_version}"
   fi
   pyenv local "${required_python_version}"
+  python -m pip install --disable-pip-version-check --quiet setuptools wheel
   python --version
 }
 

--- a/.github/ci-scripts/bash/functions-for-build
+++ b/.github/ci-scripts/bash/functions-for-build
@@ -822,7 +822,7 @@ install_python_dependencies() {
     DIR='.'
   fi
   python -m pip install --upgrade pip
-  python -m pip install flake8==5.0.4 pytest==7.1.1 twine==5.1.1 wheel==0.38.4
+  python -m pip install flake8==5.0.4 pytest==7.1.1 twine==5.1.1 wheel==0.38.4 setuptools
   if [ -f "${DIR}/requirements.txt" ]; then
     python -m pip install -r "${DIR}/requirements.txt" --trusted-host ${NEXUS_SERVER_ENDPOINT} --extra-index-url=${NEXUS_PROTOCOL}://${NEXUS_USERNAME}:${NEXUS_PASSWORD}@${NEXUS_SERVER_ENDPOINT}/repository/${NEXUS_PULL_REPOS_PY}/simple
   fi

--- a/.github/ci-scripts/bash/functions-for-build
+++ b/.github/ci-scripts/bash/functions-for-build
@@ -157,17 +157,18 @@ configure_python_version_if_required() {
     echo "Python ${required_python_version} not found. Installing..."
     pyenv install "${required_python_version}"
   fi
-  pyenv local "${required_python_version}"
-  python -m pip install --disable-pip-version-check --quiet setuptools wheel
-  python --version
+  "$(pyenv root)/versions/${required_python_version}/bin/python" --version
 }
 
 create_python_venv() {
   check_convoy_yaml
   required_python_version=$(yq e '.pythonVersion // ""' convoy.yaml 2>/dev/null)
-  [[ -n "${required_python_version:-}" ]] || return 0
   local venv_name="${1:-venv}"
-  python3 -m venv "${venv_name}"
+  if [[ -n "${required_python_version:-}" ]]; then
+    "$(pyenv root)/versions/${required_python_version}/bin/python" -m venv "${venv_name}"
+  else
+    python3 -m venv "${venv_name}"
+  fi
   source "${venv_name}/bin/activate"
   python --version
 }
@@ -745,10 +746,9 @@ initialise_coverage() {
   echo "Setting up virtual environment for running unit tests."
   venv_name=${1}
   venv_path=${PWD}/${venv_name}
-  python_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+  create_python_venv "${venv_name}"
+  python_version=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
   source_path=${venv_path}/lib/python${python_version}/site-packages/
-  python -m venv ${venv_name}
-  source ${venv_name}/bin/activate
   dist_dir=$(find . -type d -name "dist" 2>/dev/null | head -n 1)
   python -m pip install "${dist_dir}"/*.whl coverage==7.5.1 requests-mock==1.12.1 pytest-env==1.1.3 pytest==8.2.0 --extra-index-url=${NEXUS_PROTOCOL}://${NEXUS_USERNAME}:${NEXUS_PASSWORD}@${NEXUS_SERVER_ENDPOINT}/repository/${NEXUS_PULL_REPOS_PY}/simple --trusted-host ${NEXUS_SERVER_ENDPOINT}
   if [ -f "requirements_test.txt" ]; then

--- a/.github/ci-scripts/bash/functions-for-build-camel-case
+++ b/.github/ci-scripts/bash/functions-for-build-camel-case
@@ -60,6 +60,14 @@ configureGoVersionIfRequired() {
   configure_go_version_if_required "$@"
 }
 
+configurePythonVersionIfRequired() {
+  configure_python_version_if_required "$@"
+}
+
+createPythonVenv() {
+  create_python_venv "$@"
+}
+
 configureNpmrc() {
   configure_npmrc "$@"
 }

--- a/.github/workflows/master_approve.yml
+++ b/.github/workflows/master_approve.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   
   file-check:
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_file_check.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_file_check.yml@TDEVOPS-4679
     secrets: inherit
   
   read-codeowners:
     needs: file-check
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_read_codeowners.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_read_codeowners.yml@TDEVOPS-4679
     secrets: inherit
     with:
       changed-files: ${{needs.file-check.outputs.changed-files}}
@@ -19,7 +19,7 @@ jobs:
   post-message: 
     if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
     needs: read-codeowners
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_message.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_message.yml@TDEVOPS-4679
     secrets: inherit
     with:
       required-teams: ${{needs.read-codeowners.outputs.required-teams}}
@@ -58,7 +58,7 @@ jobs:
   check-approval:
     needs: [check-update-branch,read-codeowners,file-check]
     if: ${{ github.event.review.state == 'approved' || github.event.review.state == 'commented' || github.event.review.state == 'changes_requested' || needs.check-update-branch.outputs.update-branch == 'true' || (contains(github.event.pull_request.head.ref, 'double_commit')) && (github.event.pull_request.user.login == 'cipipelinetessell' ) }}
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_check_approval.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_check_approval.yml@TDEVOPS-4679
     secrets: inherit
     with:
       required-teams: ${{needs.read-codeowners.outputs.required-teams}}

--- a/.github/workflows/master_auto_merge.yml
+++ b/.github/workflows/master_auto_merge.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}

--- a/.github/workflows/master_build_dispatch.yml
+++ b/.github/workflows/master_build_dispatch.yml
@@ -28,7 +28,7 @@
                 if [[ ${APP_GROUP} == none ]]; then
                   exit 0
                 fi
-                URL="http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/${APP_GROUP}/latest-main-release-label"
+                URL="http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/${APP_GROUP}/latest-main-release-label"
                 RESPONSE=$(curl -f --location "$URL" --header "x-api-key: ${{secrets.CONVOY_AUTH_TOKEN}}")
                 echo "$RESPONSE"
                 LABEL=$(echo "$RESPONSE" | jq -r '.["latest-main-release-label"]')
@@ -66,19 +66,19 @@
   
     find-latest-tag:
       needs: [build-file]
-      uses: TessellDevelopment/convoy-ci/.github/workflows/master_find_latest_tag.yml@main
+      uses: TessellDevelopment/convoy-ci/.github/workflows/master_find_latest_tag.yml@TDEVOPS-4679
       secrets: inherit
       with:
         dev_build: ${{ needs.build-file.outputs.dev_build == 'true' }}
           
     sonar-scan:
       needs: [build-file]
-      uses: TessellDevelopment/convoy-ci/.github/workflows/master_sonar_scan.yml@main
+      uses: TessellDevelopment/convoy-ci/.github/workflows/master_sonar_scan.yml@TDEVOPS-4679
       secrets: inherit
   
     build:
       needs: [build-file,find-latest-tag]
-      uses: TessellDevelopment/convoy-ci/.github/workflows/master_build_merge.yml@main
+      uses: TessellDevelopment/convoy-ci/.github/workflows/master_build_merge.yml@TDEVOPS-4679
       secrets: inherit
       with:
         type: ${{needs.build-file.outputs.type}}

--- a/.github/workflows/master_build_merge.yml
+++ b/.github/workflows/master_build_merge.yml
@@ -668,7 +668,8 @@ jobs:
             ARTIFACT="$1"
             EXTENSION="$2"
             requiredInputs="1 2"
-            validateInputs "$requiredInputs" "$@" 
+            validateInputs "$requiredInputs" "$@"
+            installPythonDependencies "$ARTIFACT"
             gradlewUploadPlugin
             PLUGIN_NAME=$(echo "$ARTIFACT" | tr '-' '_')
             mv "build/$PLUGIN_NAME-${LATEST_TAG}.$EXTENSION" "$ARTIFACT.$EXTENSION"        

--- a/.github/workflows/master_build_merge.yml
+++ b/.github/workflows/master_build_merge.yml
@@ -1020,6 +1020,7 @@ jobs:
           BRANCH_COVERAGE=""
           STATEMENT_COVERAGE=""
           configureGoVersionIfRequired
+          configurePythonVersionIfRequired
           set -e; bash -c "$(yq ".ci.${CI_PHASE}.cmd // \"\"" convoy.yaml)"; set +e
           build "artifacts"
           build "dockerImages"

--- a/.github/workflows/master_build_merge.yml
+++ b/.github/workflows/master_build_merge.yml
@@ -51,12 +51,12 @@ env:
   BASE_BRANCH: "${{github.event.pull_request.base.ref}}"
   BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
   CITEST_APP_NAME: ${{vars.CITEST_APP_NAME}}
-  CI_BRANCH: main
+  CI_BRANCH: TDEVOPS-4679
   CI_PHASE: postMerge
   CODE_COVERAGE_S3: ${{vars.CODE_COVERAGE_S3}}
   CONTENT_FOR_GITHUB_OUTPUT: /tmp/content-for-github-output
   CONVOY_API_KEY: ${{secrets.CONVOY_AUTH_TOKEN}}
-  DEVOPS_GIT_METADATA_API_ENDPOINT: http://${{vars.CONVOY_API_ENDPOINT}}/devops/git-metadata
+  DEVOPS_GIT_METADATA_API_ENDPOINT: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/git-metadata
   DEVQA_INFRA_ACCESS_KEY: ${{ secrets.DEVQA_INFRA_ACCESS_KEY }}
   DEVQA_INFRA_SECRET_KEY: ${{ secrets.DEVQA_INFRA_SECRET_KEY }}
   DEV_BUILD: ${{inputs.dev_build}}
@@ -67,7 +67,7 @@ env:
   GITHUB_USER: ${{ secrets.CIPIPELINE_GITHUB_USER }}
   GIT_BASE_REF: ${{ github.event.pull_request.base.sha || (inputs.dev_build && inputs.GIT_BASE_REF || '') }}
   GIT_COMMIT: ${{ github.sha }}
-  IMAGE_SCAN_API_URL: http://${{vars.CONVOY_API_ENDPOINT}}/devops/code/vulnerabilities/validate
+  IMAGE_SCAN_API_URL: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/code/vulnerabilities/validate
   LABEL: ${{inputs.label}}
   LATEST_TAG: ${{inputs.tag}}
   NEXUS_PASSWORD: ${{secrets.CIPIPELINE_NEXUS_PASSWORD}}
@@ -232,7 +232,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}
@@ -486,7 +486,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}
@@ -902,7 +902,7 @@ jobs:
             mkdir -p $BUILD_DIR
             DIRECTORIES=($(ls -d */))
             EXCLUDE_DIR=("build",".github",".gitignore","convoy.yaml","README.md","ci-scripts","docs","scripts")
-            RELEASE_MANIFEST_URL=http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/${APP_GROUP}/release-manifests
+            RELEASE_MANIFEST_URL=http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/${APP_GROUP}/release-manifests
             MODIFIED_DIRECTORIES=$(modifiedDir)
             if [[ "${{github.event_name}}" == "workflow_dispatch" && !${{inputs.dev_build}} ]]; then
               MODIFIED_DIRECTORIES=${DIRECTORIES[@]}
@@ -1055,7 +1055,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}
@@ -1239,7 +1239,7 @@ jobs:
                     
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}

--- a/.github/workflows/master_build_merge.yml
+++ b/.github/workflows/master_build_merge.yml
@@ -669,6 +669,7 @@ jobs:
             EXTENSION="$2"
             requiredInputs="1 2"
             validateInputs "$requiredInputs" "$@"
+            createPythonVenv
             installPythonDependencies "$ARTIFACT"
             gradlewUploadPlugin
             PLUGIN_NAME=$(echo "$ARTIFACT" | tr '-' '_')
@@ -781,7 +782,7 @@ jobs:
               DIR='.'
             fi
             python -m pip install --upgrade pip
-            python -m pip install flake8 pytest twine wheel
+            python -m pip install flake8 pytest twine wheel setuptools
             if [ -f "${DIR}/requirements.txt" ]; then
               python -m pip install -r "${DIR}/requirements.txt" --trusted-host ${{env.NEXUS_SERVER_ENDPOINT}} --extra-index-url=${{env.NEXUS_PROTOCOL}}://${{ secrets.CIPIPELINE_NEXUS_USERNAME }}:${{ secrets.CIPIPELINE_NEXUS_PASSWORD }}@${{env.NEXUS_SERVER_ENDPOINT}}/repository/${{ env.NEXUS_PULL_REPOS_PY }}/simple;
             fi

--- a/.github/workflows/master_build_pr.yml
+++ b/.github/workflows/master_build_pr.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  CI_BRANCH: main
+  CI_BRANCH: TDEVOPS-4679
   CHANNEL_ID: ${{vars.CONVOY_ALERTS_SLACK_ID}}
   CODE_COVERAGE_S3: ${{vars.CODE_COVERAGE_S3}}
   CONVOY_API_KEY: ${{secrets.CONVOY_AUTH_TOKEN}}
@@ -20,7 +20,7 @@ env:
   GIT_COMMIT: ${{ github.sha }}
   GITHUB_TOKEN: ${{ secrets.CIPIPELINE_GITHUB_TOKEN }}
   GITHUB_USER: ${{ secrets.CIPIPELINE_GITHUB_USER }}
-  IMAGE_SCAN_API_URL: http://${{vars.CONVOY_API_ENDPOINT}}/devops/code/vulnerabilities/validate
+  IMAGE_SCAN_API_URL: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/code/vulnerabilities/validate
   NEXUS_PASSWORD: ${{secrets.CIPIPELINE_NEXUS_PASSWORD}}
   NEXUS_PULL_REPOS_M2: tessell-m2-development
   NEXUS_PULL_REPOS_PY: tessell-py-development
@@ -299,7 +299,7 @@ jobs:
       BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
       BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
       CI_PHASE: preMerge
-      DEVOPS_GIT_METADATA_API_ENDPOINT: http://${{vars.CONVOY_API_ENDPOINT}}/devops/git-metadata
+      DEVOPS_GIT_METADATA_API_ENDPOINT: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/git-metadata
       DEVQA_INFRA_ACCESS_KEY: ${{ secrets.DEVQA_INFRA_ACCESS_KEY }}
       DEVQA_INFRA_SECRET_KEY: ${{ secrets.DEVQA_INFRA_SECRET_KEY }}
       ENABLE_PACKER_E2E_SCAN: ${{vars.ENABLE_PACKER_E2E_SCAN}}

--- a/.github/workflows/master_build_pr.yml
+++ b/.github/workflows/master_build_pr.yml
@@ -425,6 +425,7 @@ jobs:
             ARTIFACT="$1"
             requiredInputs="1"
             validateInputs "$requiredInputs" "$@"
+            createPythonVenv
             installPythonDependencies "$ARTIFACT"
             lintCheck
             gradlewPackagePlugin

--- a/.github/workflows/master_build_pr.yml
+++ b/.github/workflows/master_build_pr.yml
@@ -732,6 +732,7 @@ jobs:
           source ./ci-scripts/bash/functions-for-build
           [[ -n ${LATEST_TAG:-} ]] || export LATEST_TAG=0.0.0
           configureGoVersionIfRequired
+          configurePythonVersionIfRequired
           set -e; bash -c "$(yq ".ci.${CI_PHASE}.cmd // \"\"" convoy.yaml)"; set +e
           build "artifacts"
           build "dockerImages"

--- a/.github/workflows/master_build_pr.yml
+++ b/.github/workflows/master_build_pr.yml
@@ -424,7 +424,8 @@ jobs:
             set -e
             ARTIFACT="$1"
             requiredInputs="1"
-            validateInputs "$requiredInputs" "$@" 
+            validateInputs "$requiredInputs" "$@"
+            installPythonDependencies "$ARTIFACT"
             lintCheck
             gradlewPackagePlugin
             set +e

--- a/.github/workflows/master_create_double_commit.yml
+++ b/.github/workflows/master_create_double_commit.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: non-build
     env:
-      CI_BRANCH: main
+      CI_BRANCH: TDEVOPS-4679
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL  }}
     steps:
       - uses: actions/checkout@v4.1.1
@@ -40,7 +40,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}

--- a/.github/workflows/master_create_tag.yml
+++ b/.github/workflows/master_create_tag.yml
@@ -222,7 +222,7 @@ jobs:
             else
               validate_label=true
               if [[ "${{ github.event.pull_request.base.ref }}" == "main" ]]; then
-                URL="http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/latest-main-release-label"
+                URL="http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/latest-main-release-label"
                 RESPONSE=$(curl -f --location "$URL" --header "x-api-key: ${{secrets.CONVOY_AUTH_TOKEN}}")
                 echo "$RESPONSE"
                 LABEL=$(echo "$RESPONSE" | jq -r '.["latest-main-release-label"]')
@@ -258,7 +258,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}

--- a/.github/workflows/master_deployment.yml
+++ b/.github/workflows/master_deployment.yml
@@ -17,7 +17,7 @@ jobs:
       APP_GROUP: "${{inputs.app_group}}"
       BASE_BRANCH: "${{github.event.pull_request.base.ref}}"
       CD_COMMAND: "${{inputs.cd_command}}"
-      CI_BRANCH: main
+      CI_BRANCH: TDEVOPS-4679
       TESSELL_GCP_APP_NAME: ${{ vars.TESSELL_GCP_APP_NAME }}
       TESSELL_GCP_PROJECT_ID: ${{vars.TESSELL_GCP_PROJECT_ID}}
       TESSELL_GCP_SERVICE_ACCOUNT_NAME: ${{vars.TESSELL_GCP_SERVICE_ACCOUNT_NAME}}

--- a/.github/workflows/master_dev_checks.yml
+++ b/.github/workflows/master_dev_checks.yml
@@ -8,7 +8,7 @@
     dev-checks:
       runs-on: non-build
       env:
-        CI_BRANCH: main
+        CI_BRANCH: TDEVOPS-4679
       steps:
         - name: Dump GitHub context
           env:
@@ -509,7 +509,7 @@
             APP_GROUP=$(yq '.appGroup' convoy.yaml)
 
             echo "Fetching release manifest for appGroup: $APP_GROUP ..."
-            curl -sfL "http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/${APP_GROUP}/release-manifests/${TARGET_BRANCH}?latest=true" \
+            curl -sfL "http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/${APP_GROUP}/release-manifests/${TARGET_BRANCH}?latest=true" \
               --header "x-api-key: ${{secrets.CONVOY_AUTH_TOKEN}}" -o release_manifest.json || { echo "::error::Failed to fetch release manifest."; exit 1; }
 
             echo "Validating consumed artifacts..."

--- a/.github/workflows/master_find_latest_tag.yml
+++ b/.github/workflows/master_find_latest_tag.yml
@@ -137,7 +137,7 @@ jobs:
           
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}

--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -27,14 +27,14 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}
 
   file-check:
     needs: check-label-cut-status
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_file_check.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_file_check.yml@TDEVOPS-4679
     secrets: inherit
 
   runner-check:
@@ -82,7 +82,7 @@ jobs:
                 echo "LABEL=rel-0.0.0" >> $GITHUB_OUTPUT
                 exit 0
               fi
-              URL="http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/latest-main-release-label"
+              URL="http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/latest-main-release-label"
               RESPONSE=$(curl -f --location "$URL" --header "x-api-key: ${{secrets.CONVOY_AUTH_TOKEN}}")
               echo "$RESPONSE"
               LABEL=$(echo "$RESPONSE" | jq -r '.["latest-main-release-label"]')
@@ -109,7 +109,7 @@ jobs:
 
   create-tag:
     needs: runner-check
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_create_tag.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_create_tag.yml@TDEVOPS-4679
     secrets: inherit
     with:
       label: ${{needs.runner-check.outputs.label}}
@@ -117,7 +117,7 @@ jobs:
   post-tag-to-convoy:
     needs: create-tag
     if: needs.runner-check.outputs.app_group != 'none'
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_tag_convoy.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_tag_convoy.yml@TDEVOPS-4679
     secrets: inherit
     with:
       tag: ${{needs.create-tag.outputs.tag}}
@@ -126,7 +126,7 @@ jobs:
   build:
     needs: [runner-check, create-tag]
     # if: needs.file-check.outputs.github-changes == 'false'
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_build_merge.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_build_merge.yml@TDEVOPS-4679
     secrets: inherit
     with:
       type: ${{needs.runner-check.outputs.type}}
@@ -136,7 +136,7 @@ jobs:
   post-build-to-convoy:
     if: needs.runner-check.outputs.app_group != 'none' && always()
     needs: [file-check, create-tag, build, runner-check, post-tag-to-convoy]
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_build_convoy.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_build_convoy.yml@TDEVOPS-4679
     secrets: inherit
     with:
       # IS_ANY_ARTIFACT_GENERATED: ${{ needs.file-check.outputs.github-changes == 'false' }}
@@ -148,13 +148,13 @@ jobs:
 
   sonar-scan:
     needs: post-build-to-convoy
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_sonar_scan.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_sonar_scan.yml@TDEVOPS-4679
     secrets: inherit
 
   post-coverage-to-convoy:
     needs: [create-tag, build, runner-check]
     if: needs.runner-check.outputs.app_group != 'none'
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_coverage_convoy.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_post_coverage_convoy.yml@TDEVOPS-4679
     secrets: inherit
     with:
       BRANCH_COVERAGE: ${{needs.build.outputs.BRANCH_COVERAGE}}
@@ -165,13 +165,13 @@ jobs:
   create-double-commit:
     if: always()
     needs: build
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_create_double_commit.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_create_double_commit.yml@TDEVOPS-4679
     secrets: inherit
 
   exec-deployment-script:
     if: ${{ needs.runner-check.outputs.exec_cd == 'true' }}
     needs: [runner-check, post-build-to-convoy]
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_deployment.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_deployment.yml@TDEVOPS-4679
     secrets: inherit
     with:
       app_group: ${{needs.runner-check.outputs.app_group}}
@@ -180,5 +180,5 @@ jobs:
   send-mail:
     needs: create-double-commit
     if: failure() && (contains(github.event.pull_request.head.ref, 'double_commit'))
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_send_email.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_send_email.yml@TDEVOPS-4679
     secrets: inherit

--- a/.github/workflows/master_patch_service_manifest.yaml
+++ b/.github/workflows/master_patch_service_manifest.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: PATCH API to Convoy
         run: |
           set -e
-          RESPONSE=$(curl --location --request PATCH -i -s -o /dev/null -w "%{http_code}" "http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/service-manifest" \
+          RESPONSE=$(curl --location --request PATCH -i -s -o /dev/null -w "%{http_code}" "http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/service-manifest" \
             --header "x-api-key: ${{secrets.CONVOY_AUTH_TOKEN}}" \
             --data '')
           echo "$RESPONSE"
@@ -27,7 +27,7 @@ jobs:
           
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.CONVOY_ALERTS_SLACK_CHANNEL }}

--- a/.github/workflows/master_post_build_convoy.yml
+++ b/.github/workflows/master_post_build_convoy.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: POST API to Convoy
         env:
-          API_URL: http://${{vars.CONVOY_API_ENDPOINT}}/devops/git-metadata/build-status
-          API_URL_REPLICATE: http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/replicate-artifacts
+          API_URL: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/git-metadata/build-status
+          API_URL_REPLICATE: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/replicate-artifacts
           API_KEY: ${{secrets.CONVOY_AUTH_TOKEN}}
           ARTIFACT_CHECKSUMS: ${{inputs.ARTIFACT_CHECKSUMS}}
           CONTENT_FOR_GITHUB_OUTPUT: /tmp/content-for-github-output
@@ -292,7 +292,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.CONVOY_ALERTS_SLACK_CHANNEL }}

--- a/.github/workflows/master_post_coverage_convoy.yml
+++ b/.github/workflows/master_post_coverage_convoy.yml
@@ -40,7 +40,7 @@
   
         - name: POST API to Convoy
           env:
-            API_URL: http://${{vars.CONVOY_API_ENDPOINT}}/devops/code/coverage
+            API_URL: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/code/coverage
             API_KEY: ${{secrets.CONVOY_AUTH_TOKEN}}
             BASE_BRANCH: "${{github.event.pull_request.base.ref}}"
             BRANCH_COVERAGE: "${{env.BRANCH_COVERAGE}}"
@@ -137,7 +137,7 @@
   
         - name: Slack Notification
           if: failure()
-          uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+          uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
           with:
             steps: ${{ toJson(steps) }}
             channel: ${{ secrets.CONVOY_ALERTS_SLACK_CHANNEL }}

--- a/.github/workflows/master_post_tag_convoy.yml
+++ b/.github/workflows/master_post_tag_convoy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: POST API to Convoy
         env:
-          API_URL: http://${{vars.CONVOY_API_ENDPOINT}}/devops/git-metadata/commits
+          API_URL: http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/git-metadata/commits
           API_KEY: ${{secrets.CONVOY_AUTH_TOKEN}}
           COMMIT_HASH: "${{github.sha}}"
           COMMITTED_AT: "${{github.event.pull_request.merged_at}}"
@@ -124,7 +124,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.CONVOY_ALERTS_SLACK_CHANNEL }}

--- a/.github/workflows/master_pr.yml
+++ b/.github/workflows/master_pr.yml
@@ -6,11 +6,11 @@ on:
 jobs:
 
   dev-checks:
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_dev_checks.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_dev_checks.yml@TDEVOPS-4679
     secrets: inherit
 
   version-check:
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_check_version.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_check_version.yml@TDEVOPS-4679
     secrets: inherit
 
   runner-check:
@@ -32,7 +32,7 @@ jobs:
 
   build:
     needs: runner-check
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_build_pr.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_build_pr.yml@TDEVOPS-4679
     with:
       type: ${{needs.runner-check.outputs.type}}
     secrets: inherit
@@ -80,11 +80,11 @@ jobs:
   auto-merge:
     needs: build
     if: (contains(github.event.pull_request.head.ref, 'double_commit')) && (github.event.pull_request.user.login == 'cipipelinetessell' ) && always()
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_auto_merge.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_auto_merge.yml@TDEVOPS-4679
     secrets: inherit 
 
   send-mail:
     needs: auto-merge
     if: failure() && (contains(github.event.pull_request.head.ref, 'double_commit'))
-    uses: TessellDevelopment/convoy-ci/.github/workflows/master_send_email.yml@main
+    uses: TessellDevelopment/convoy-ci/.github/workflows/master_send_email.yml@TDEVOPS-4679
     secrets: inherit

--- a/.github/workflows/master_sonar_scan.yml
+++ b/.github/workflows/master_sonar_scan.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.ref_name == 'main' ||  github.event.pull_request.base.ref == 'main'
     runs-on: self-hosted
     env:
-      CI_BRANCH: main
+      CI_BRANCH: TDEVOPS-4679
       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Slack Notification
         if: failure()
-        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@main
+        uses: TessellDevelopment/convoy-ci/.github/actions/slack-notify@TDEVOPS-4679
         with:
           steps: ${{ toJson(steps) }}
           channel: ${{ secrets.SLACK_DEVOPS_CHANNEL }}

--- a/.github/workflows/packer_workflow_dispatch.yml
+++ b/.github/workflows/packer_workflow_dispatch.yml
@@ -75,9 +75,9 @@ jobs:
           echo "$APP_GROUP"
           echo "APP_GROUP=$APP_GROUP" >> $GITHUB_ENV
           if [[ "${{ env.BASE_BRANCH }}" == "main" || "${{ env.BASE_BRANCH }}" == rel-* ]]; then
-            URL="http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/release-manifests/${{ env.BASE_BRANCH }}"
+            URL="http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/release-manifests/${{ env.BASE_BRANCH }}"
           elif [[ "${{ env.SOFTWARE_IMAGE_BASE_RELEASE }}" == "main" || "${{ env.SOFTWARE_IMAGE_BASE_RELEASE }}" == rel-* ]]; then
-            URL="http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/release-manifests/${{ env.SOFTWARE_IMAGE_BASE_RELEASE }}"
+            URL="http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/release-manifests/${{ env.SOFTWARE_IMAGE_BASE_RELEASE }}"
           fi
 
           echo "$URL"
@@ -102,7 +102,7 @@ jobs:
           if [[ "${{ env.BASE_BRANCH }}" == "main" ]]; then
             APP_GROUP=$(yq '.appGroup // "tessell"' convoy.yaml)
             echo "$APP_GROUP"
-            URL="http://${{vars.CONVOY_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/latest-main-release-label"
+            URL="http://${{vars.CONVOY_DEV_API_ENDPOINT}}/devops/applications/app-groups/$APP_GROUP/latest-main-release-label"
             echo "$URL"
             RESPONSE=$(curl -f --location "$URL" --header "x-api-key: ${{secrets.CONVOY_AUTH_TOKEN}}")
             echo "$RESPONSE"


### PR DESCRIPTION
# Description
convoy.yaml's pythonVersion was only applied inside a couple of Python-specific build functions (initialize_python_build_env, setup_packer_env). Gradle-based builds (e.g. tessell-db-plugin-mysql) never called it, so their Gradle tasks that shell out to python resolved to the runner's system version (often 3.8) instead of the declared one.
Moved pyenv configuration (configurePythonVersionIfRequired) to the step top in master_build_pr.yml / master_build_merge.yml so .python-version is written once before any build function runs. Build functions can still create/activate a venv as needed and deactivate afterwards.

Fixes # (issue)

Dependent Services #
- [ ] Governance
- [ ] IAM
- [ ] Deployer
- [ ] DB Systems
- [ ] Tenant
- [ ] Software Library
- [ ] Backup
- [ ] Conductor
- [ ] Monitoring
- [ ] DMM

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Environment**:

- [ ] Dev
- [ ] Staging

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
